### PR TITLE
chore: Ignore `/vite` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ testem.log
 # System files
 .DS_Store
 Thumbs.db
+
+# Vite
+/vite

--- a/package.json
+++ b/package.json
@@ -50,5 +50,6 @@
     "react-dom": "^18.2.0",
     "storybook": "^7.6.17",
     "typescript": "~5.3.2"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,5 @@
     "react-dom": "^18.2.0",
     "storybook": "^7.6.17",
     "typescript": "~5.3.2"
-  },
-  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
+  }
 }


### PR DESCRIPTION
This PR adds the `/vite` directory to `.gitignore` to prevent it from being tracked by Git, keeping the repository clean from build artifacts.

Closes #5