### PR TITLE
fix: change build script in `package.json` for Chromatic CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "storybook": "npm run compodoc:build && npm run storybook:dev",
     "compodoc:build": "compodoc -p ./.storybook/tsconfig.doc.json -e json -d ./",
     "storybook:dev": "storybook dev",
-    "storybook:build": "storybook build"
+    "build-storybook": "storybook build"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
- Change the `storybook:build` script to `build-storybook`

The Chromatic CLI is unable to locate the `build-storybook` script in the `package.json` file, preventing it from building Storybook correctly.
Any other name requires additional configuration flags to be passed to the Chromatic CLI.
It's more practical to rely on the default config, leaving alternate configurations for unique scenarios.

Closes #8