### PR TITLE
feat: update to Analog Vite Plugin to 1.7.3-beta.5 and remove prod build workarounds

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -29,27 +29,6 @@ const config = {
      */
     const storybookAngularImportPlugin = () => ({
       name: '@storybook/angular',
-      config() {
-        return <UserConfig>{
-          build: {
-            minify: false,
-            rollupOptions: {
-              plugins: [
-                {
-                  name: 'disable-compiler-treeshake',
-                  transform(_code: string, id: string) {
-                    if (id.includes('compiler')) {
-                      return { moduleSideEffects: 'no-treeshake' };
-                    }
-
-                    return;
-                  }
-                }
-              ]
-            }
-          },
-        }
-      },      
       transform(code: string) {
         if (code.includes('"@storybook/angular"')) {
           return code.replace(/\"@storybook\/angular\"/g, '\"@storybook/angular/dist/client\"');

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,10 +1,15 @@
-import '@angular/compiler';
-import type { Preview } from '@storybook/angular';
+import { applicationConfig, type Preview } from '@storybook/angular/dist/client';
 import { setCompodocJson } from '@storybook/addon-docs/angular';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import docJson from '../documentation.json';
 setCompodocJson(docJson);
 
 const preview: Preview = {
+  decorators: [
+    applicationConfig({
+      providers: [provideNoopAnimations()]
+    })
+  ],
   parameters: {
     controls: {
       matchers: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,11 +21,12 @@
         "zone.js": "~0.14.3"
       },
       "devDependencies": {
-        "@analogjs/vite-plugin-angular": "^1.2.2",
+        "@analogjs/vite-plugin-angular": "^1.7.3-beta.5",
         "@angular-devkit/build-angular": "^17.2.2",
         "@angular/cli": "^17.2.2",
         "@angular/compiler-cli": "^17.2.0",
         "@compodoc/compodoc": "^1.1.23",
+        "@ngtools/webpack": "^17.2.0",
         "@storybook/addon-essentials": "~8.1.0",
         "@storybook/addon-interactions": "~8.1.0",
         "@storybook/addon-links": "~8.1.0",
@@ -70,15 +71,21 @@
       }
     },
     "node_modules/@analogjs/vite-plugin-angular": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@analogjs/vite-plugin-angular/-/vite-plugin-angular-1.2.2.tgz",
-      "integrity": "sha512-VA9gYNOHlDWpdUykj27Fb70OhrRNo32SnaFDIGbukAWLgll6FFKHDE9gcosxBGZorGv/ILmhrUR+1mTj2MbLoA==",
+      "version": "1.7.3-beta.5",
+      "resolved": "https://registry.npmjs.org/@analogjs/vite-plugin-angular/-/vite-plugin-angular-1.7.3-beta.5.tgz",
+      "integrity": "sha512-T44oITNKaaCMaFOBAluddjSN3F8O4w5oDGMRRdzu3E5Pwoqu7KuVX2bCYlZ3589Qv2IzXc4b3lbQgHvC670L4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ts-morph": "^21.0.0"
       },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/brandonroberts"
+      },
       "peerDependencies": {
-        "@angular-devkit/build-angular": "^15.0.0 || >=16.0.0"
+        "@angular-devkit/build-angular": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "@ngtools/webpack": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@angular-devkit/architect": {

--- a/package.json
+++ b/package.json
@@ -27,10 +27,11 @@
     "zone.js": "~0.14.3"
   },
   "devDependencies": {
-    "@analogjs/vite-plugin-angular": "^1.2.2",
+    "@analogjs/vite-plugin-angular": "^1.7.3-beta.5",
     "@angular-devkit/build-angular": "^17.2.2",
     "@angular/cli": "^17.2.2",
     "@angular/compiler-cli": "^17.2.0",
+    "@ngtools/webpack": "^17.2.0",
     "@compodoc/compodoc": "^1.1.23",
     "@storybook/addon-essentials": "~8.1.0",
     "@storybook/addon-interactions": "~8.1.0",

--- a/src/stories/button.component.ts
+++ b/src/stories/button.component.ts
@@ -1,10 +1,10 @@
-import { NgClass, NgStyle } from '@angular/common';
+import { CommonModule } from '@angular/common';
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 
 @Component({
   selector: 'storybook-button',
   standalone: true,
-  imports: [NgClass, NgStyle],
+  imports: [CommonModule],
   template: ` <button
     type="button"
     (click)="onClick.emit($event)"

--- a/src/stories/header.component.ts
+++ b/src/stories/header.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
-import { NgIf } from '@angular/common';
+import { CommonModule } from '@angular/common';
 
 import { ButtonComponent } from './button.component';
 import type { User } from './user';
@@ -7,7 +7,7 @@ import type { User } from './user';
 @Component({
   selector: 'storybook-header',
   standalone: true,
-  imports: [NgIf, ButtonComponent],
+  imports: [CommonModule, ButtonComponent],
   template: `<header>
     <div class="storybook-header">
       <div>

--- a/src/stories/page.component.ts
+++ b/src/stories/page.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
 
 import { HeaderComponent } from './header.component';
 import type { User } from './user';
@@ -6,7 +7,7 @@ import type { User } from './user';
 @Component({
   selector: 'storybook-page',
   standalone: true,
-  imports: [HeaderComponent],
+  imports: [CommonModule, HeaderComponent],
   template: `<article>
     <storybook-header
       [user]="user"


### PR DESCRIPTION
- Updates to `@analogjs/vite-plugin-angular` to 1.7.3-beta.5 to fix the bug of not being able to use `CommonModule`, `FormsModule`, etc.
- Removes workaround for prod builds for the Angular Compiler
- Adds example usage of CommonModule